### PR TITLE
Execution of malicious exif data

### DIFF
--- a/views/default/photos/sidebar/exif.php
+++ b/views/default/photos/sidebar/exif.php
@@ -3,18 +3,22 @@
  * EXIF sidebar module
  */
 
-$image = $vars['image'];
+$image = $vars["image"];
 
-elgg_load_library('tidypics:exif');
+elgg_load_library("tidypics:exif");
 
 $exif = tp_exif_formatted($image);
 if ($exif) {
 	$title = "EXIF";
-	$body = '<table class="elgg-table elgg-table-alt">';
+	
+	$body = "<table class='elgg-table elgg-table-alt'>";
 	foreach ($exif as $key => $value) {
-		$body .= "<tr><td>$key</td><td>$value</td></tr>";
+		$body .= "<tr>";
+		$body .= "<td>" . elgg_view("output/text", array("value" => filter_tags($key))) . "</td>";
+		$body .= "<td>" . elgg_view("output/text", array("value" => filter_tags($value))) . "</td>";
+		$body .= "</tr>";
 	}
-	$body .= '</table>';
+	$body .= "</table>";
 
-	echo elgg_view_module('aside', $title, $body);
+	echo elgg_view_module("aside", $title, $body);
 }


### PR DESCRIPTION
If someone put malicious data in the exif data of a picture this is executed when you view the photo.

In the sidebar where the exif data is shown, this isn't filtered in the output.
