### PR TITLE
More robust method for creating the image directory

### DIFF
--- a/classes/TidypicsImage.php
+++ b/classes/TidypicsImage.php
@@ -201,19 +201,20 @@ class TidypicsImage extends ElggFile {
 	protected function saveImageFile($data) {
 		$this->checkUploadErrors($data);
 
+		$this->setOriginalFilename($data['name']);
+		$filename = $this->getFilenameOnFilestore();
+		
 		// we need to make sure the directory for the album exists
 		// @note for group albums, the photos are distributed among the users
-		$dir = tp_get_img_dir() . $this->getContainerGUID();
+		$dir = dirname($filename);
 		if (!file_exists($dir)) {
 			mkdir($dir, 0755, true);
 		}
 
 		// move the uploaded file into album directory
-		$this->setOriginalFilename($data['name']);
-		$filename = $this->getFilenameOnFilestore();
 		$result = move_uploaded_file($data['tmp_name'], $filename);
 		if (!$result) {
-			return false;
+			throw new Exception("Failed to move uploaded file {$data['tmp_name']} to $filename");
 		}
 
 		$owner = $this->getOwnerEntity();


### PR DESCRIPTION
For whatever reason, tp_get_img_dir stopped returning the expected value on one site I run. This patch fixes the issue and seems like a more robust approach to creating the necessary directory because it avoids using two distinct code paths to create related file paths.
